### PR TITLE
Renamed _roles instance variable to roles for Bitmask method.

### DIFF
--- a/lib/methods/bitmask.rb
+++ b/lib/methods/bitmask.rb
@@ -3,27 +3,25 @@
 module EasyRoles
   # Bitmask support
   class Bitmask
-    # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/MethodLength
     def initialize(base, column_name, _options)
-      base.send :define_method, :_roles= do |roles|
+      base.send :define_method, :roles= do |roles|
         states = base.const_get(column_name.upcase.to_sym)
         self[column_name.to_sym] = (roles & states).map { |r| 2**states.index(r) }.sum
       end
 
-      base.send :define_method, :_roles do
+      base.send :define_method, :roles do
         states = base.const_get(column_name.upcase.to_sym)
         masked_integer = self[column_name.to_sym] || 0
         states.reject.with_index { |_r, i| masked_integer[i].zero? }
       end
 
       base.send :define_method, :has_role? do |role|
-        _roles.include?(role)
+        roles.include?(role)
       end
 
       base.send :define_method, :add_role do |*roles|
         roles.each do |role|
-          self._roles = _roles.push(role).uniq
+          self.roles = self.roles.push(role).uniq
         end
       end
 
@@ -35,9 +33,9 @@ module EasyRoles
       end
 
       base.send :define_method, :remove_role do |role|
-        new_roles = _roles
+        new_roles = roles
         new_roles.delete(role)
-        self._roles = new_roles
+        self.roles = new_roles
       end
 
       base.send :define_method, :remove_role! do |role|
@@ -76,8 +74,5 @@ module EasyRoles
         })
       end
     end
-    # rubocop:enable Metrics/AbcSize
-
-    # rubocop:enable Metrics/MethodLength
   end
 end

--- a/spec/methods/bitmask_spec.rb
+++ b/spec/methods/bitmask_spec.rb
@@ -8,18 +8,18 @@ describe EasyRoles do
     it 'should allow me to set a users role' do
       user = BitmaskUser.new
       user.add_role 'admin'
-      expect(user._roles). to include 'admin'
+      expect(user.roles). to include 'admin'
     end
 
     it 'should allow me to set multiple roles at one time' do
       user = BitmaskUser.new
       user.add_roles 'admin', 'manager'
-      expect(user._roles).to include 'admin'
-      expect(user._roles).to include 'manager'
-      expect(user._roles.length).to eq 2
+      expect(user.roles).to include 'admin'
+      expect(user.roles).to include 'manager'
+      expect(user.roles.length).to eq 2
       user.add_roles 'admin', 'manager','user'
-      expect(user._roles).to include 'user'
-      expect(user._roles.length).to eq 3
+      expect(user.roles).to include 'user'
+      expect(user.roles.length).to eq 3
     end
 
     it 'should return true for is_admin? if the admin role is added to the user' do
@@ -53,9 +53,9 @@ describe EasyRoles do
     it 'should only add valid roles when adding multiple roles' do
       user = BitmaskUser.new
       user.add_roles 'admin', 'manager', 'lolcat'
-      expect(user._roles.length).to eq 2
-      expect(user._roles).to include 'admin'
-      expect(user._roles).to include 'manager'
+      expect(user.roles.length).to eq 2
+      expect(user.roles).to include 'admin'
+      expect(user.roles).to include 'manager'
     end
 
     describe 'normal methods' do
@@ -154,12 +154,12 @@ describe EasyRoles do
       it 'should allow me to set multiple roles at one time' do
         user = BitmaskUser.new
         user.add_roles! 'admin', 'manager'
-        expect(user._roles).to include 'admin'
-        expect(user._roles).to include 'manager'
-        expect(user._roles.length).to eq 2
+        expect(user.roles).to include 'admin'
+        expect(user.roles).to include 'manager'
+        expect(user.roles.length).to eq 2
         user.add_roles! 'admin', 'manager','user'
-        expect(user._roles).to include 'user'
-        expect(user._roles.length).to eq 3
+        expect(user.roles).to include 'user'
+        expect(user.roles.length).to eq 3
       end
 
       it 'should remove a role and save' do


### PR DESCRIPTION
Not sure why the Bitmask role method needed an underscore in the `_roles` instance variable but it has been refactored and tested.